### PR TITLE
Custom transition issue

### DIFF
--- a/lib/src/routes_tree/src/tree_builder.dart
+++ b/lib/src/routes_tree/src/tree_builder.dart
@@ -31,6 +31,7 @@ class TreeBuilder {
           path: '/',
           name: '${route.name} Init',
           page: (c) => Container(),
+          pageType: route.pageType,
         ));
       }
       _route.children.addAll(_buildTree(tree, route.children, fullPath));
@@ -66,7 +67,8 @@ class TreeBuilder {
           newRoute = QRoute(
               path: pathSegments[i],
               page: (c) => c.childRouter,
-              children: [newRoute]);
+              children: [newRoute],
+              pageType: route.pageType);
         }
         path = pathSegments.first;
         route = newRoute;
@@ -91,7 +93,10 @@ class TreeBuilder {
 
       final newRoute = group.value.any(notHasChildren)
           ? group.value.firstWhere(notHasChildren)
-          : QRoute(path: group.key, page: (c) => c.childRouter);
+          : QRoute(
+              path: group.key,
+              page: (c) => c.childRouter,
+              pageType: group.value.first.pageType);
 
       final children = group.value
           .where((e) => e.children != null || e.children.isNotEmpty)


### PR DESCRIPTION
This should fix the custom transition issue from v0.3.5.

BTW, I think it's probably better to rethink/redesign the ```pageType```. 

There are some package-generated QRoutes that not specifying ```pageType``` parameter so that they will use the default QRPlatformPage. This will lead to inconsistency for the transitions(vs QRCustomPage). The users cannot change them because the package generated them.
I think it's good to have one user-defined pageType that could be used as the default pageType for package-generated QRoutes. So I can just set the pageType once and all the QRoutes using the same pageType/transitions.
 
The Page Not Found route could also use this user-defined pageType if they provide.

