### PR TITLE
feat: Support for onExited callback in QMiddleware

### DIFF
--- a/lib/src/controllers/middleware_controller.dart
+++ b/lib/src/controllers/middleware_controller.dart
@@ -45,6 +45,15 @@ class MiddlewareController {
     }
   }
 
+  Future runOnExited() async {
+    if (!route.hasMiddleware) {
+      return;
+    }
+    for (var middle in route.route.middleware!) {
+      await middle.onExited();
+    }
+  }
+
   Future runOnMatch() async {
     if (!route.hasMiddleware) {
       return;

--- a/lib/src/controllers/pages_controller.dart
+++ b/lib/src/controllers/pages_controller.dart
@@ -52,6 +52,10 @@ class PagesController {
     routes.removeLast(); // remove from the routes
     pages.removeLast(); // remove from the pages
     _checkEmptyStack();
+    Future.delayed(
+      const Duration(milliseconds: 500),
+      () => middleware.runOnExited(), // run on exited
+    );
     return PopResult.Popped;
   }
 
@@ -68,6 +72,10 @@ class PagesController {
     routes.removeAt(index); // remove from the routes
     pages.removeAt(index); // remove from the pages
     _checkEmptyStack();
+    Future.delayed(
+      const Duration(milliseconds: 500),
+      () => middleware.runOnExited(), // run on exited
+    );
     return true;
   }
 

--- a/lib/src/routes/qmiddleware.dart
+++ b/lib/src/routes/qmiddleware.dart
@@ -21,6 +21,10 @@ class QMiddleware {
 
   /// This method will be called before removing the page from the stack
   Future onExit() async {}
+
+  /// This method will be called after removing the page from the stack
+  /// Useful to dispose any dependencies
+  Future onExited() async {}
 }
 
 class QMiddlewareBuilder extends QMiddleware {
@@ -61,13 +65,19 @@ class QMiddlewareBuilder extends QMiddleware {
   /// ````
   final Future<bool> Function()? canPopFunc;
 
-  QMiddlewareBuilder(
-      {this.redirectGuardFunc,
-      this.redirectGuardNameFunc,
-      this.onMatchFunc,
-      this.onEnterFunc,
-      this.canPopFunc,
-      this.onExitFunc});
+  /// This method will be called after removing the page from the stack
+  /// Useful to dispose any dependencies
+  final Future Function()? onExitedFunc;
+
+  QMiddlewareBuilder({
+    this.redirectGuardFunc,
+    this.redirectGuardNameFunc,
+    this.onMatchFunc,
+    this.onEnterFunc,
+    this.canPopFunc,
+    this.onExitFunc,
+    this.onExitedFunc,
+  });
 
   @override
   Future onEnter() async {
@@ -80,6 +90,13 @@ class QMiddlewareBuilder extends QMiddleware {
   Future onExit() async {
     if (onExitFunc != null) {
       await onExitFunc!();
+    }
+  }
+
+  @override
+  Future onExited() async {
+    if (onExitedFunc != null) {
+      await onExitedFunc!();
     }
   }
 

--- a/test/middleware_test.dart
+++ b/test/middleware_test.dart
@@ -28,6 +28,7 @@ void main() {
             QMiddlewareBuilder(
               onEnterFunc: () async => counter++,
               onExitFunc: () async => counter++,
+              onExitedFunc: () async => counter++,
               onMatchFunc: () async => counter++,
             )
           ],
@@ -43,6 +44,7 @@ void main() {
             QMiddlewareBuilder(
               onEnterFunc: () async => counter++,
               onExitFunc: () async => counter++,
+              onExitedFunc: () async => counter++,
               onMatchFunc: () async => counter++,
             )
           ],
@@ -50,7 +52,7 @@ void main() {
       QRoute(
           path: '/three', builder: () => const Scaffold(body: WidgetThree())),
     ];
-    test('Redirect / onEnter / onMatch / onExited', () async {
+    test('Redirect / onEnter / onMatch / onExit / onExited', () async {
       QR.reset();
       QRouterDelegate(routes);
       await QR.to('/nested');
@@ -63,6 +65,8 @@ void main() {
       expectedPath('/nested/child');
       await QR.navigator.replaceAll('/three');
       expect(counter, 7); // Nested onExit + Two onExit
+      await Future.delayed(const Duration(milliseconds: 500));
+      expect(counter, 9); // Nested onExited + Two onExited
     });
 
     test('Redirect guard has the right path and param', () async {
@@ -156,6 +160,7 @@ void main() {
       await widgetTester.tap(find.text('Yes'));
       await widgetTester.pumpAndSettle();
       expect(find.text('Yes'), findsNothing);
+      await widgetTester.pumpAndSettle();
       expectedPath('/');
       expect(find.byType(WidgetOne), findsOneWidget);
       expect(true, secondDialogDone);


### PR DESCRIPTION
This method will be called after the page goes completely out of the scope, so you can fire your custom events mostly like deleting the dependencies

Signed-off-by: tejHackerDEV <tejasimha222@gmail.com>