### PR TITLE
Fix replaceLastName Bug

### DIFF
--- a/lib/src/controllers/qrouter_controller.dart
+++ b/lib/src/controllers/qrouter_controller.dart
@@ -200,7 +200,12 @@ class QRouterController extends QNavigator {
   Future<void> replaceLastName(String name,
       {Map<String, dynamic>? params}) async {
     final last = _pagesController.routes.last;
-    return replaceName(last.name, name, params: params);
+    return replaceName(
+      last.name,
+      name,
+      params: last.params?.asMap,
+      withParams: params,
+    );
   }
 
   @override


### PR DESCRIPTION
This PR fixed a bug in the replaceLastName() function **/lib/src/controllers/qrouter_controller.dart** that is using the current route params as the params for the next route which is causing an error because the findName() function will be using the wrong params to search for matching route.

fixes #78