### PR TITLE
Fix route restoration

### DIFF
--- a/lib/src/routers/router_delegate.dart
+++ b/lib/src/routers/router_delegate.dart
@@ -116,7 +116,7 @@ class QRouterDelegate extends RouterDelegate<String> with ChangeNotifier {
       QR.back();
       return;
     }
-    await QR.to(configuration);
+    await QR.to(configuration, ignoreSamePath: false);
     return;
   }
 

--- a/lib/src/types/route_parser.dart
+++ b/lib/src/types/route_parser.dart
@@ -9,10 +9,9 @@ class QRouteInformationParser extends RouteInformationParser<String> {
   @override
   Future<String> parseRouteInformation(
           RouteInformation routeInformation) async =>
-      SynchronousFuture(
-          Uri.decodeFull(routeInformation.location ?? '/').toString());
+      SynchronousFuture(routeInformation.uri.path);
 
   @override
   RouteInformation restoreRouteInformation(String configuration) =>
-      RouteInformation(location: Uri.encodeFull(QR.currentPath).toString());
+      RouteInformation(uri: Uri.parse(QR.currentPath));
 }


### PR DESCRIPTION
Restore to / did not work due to ignoreSamePath.
routeInformation.location is deprecated and Uri.decodeFull threw an exception in some cases.