### PR TITLE
Full path matching is attempted when the child route cannot be matched

### DIFF
--- a/lib/src/controllers/match_controller.dart
+++ b/lib/src/controllers/match_controller.dart
@@ -188,6 +188,16 @@ class MatchController {
       searchIn = match.children!;
       match.child = await _tryFind(searchIn, _searchIndex);
       if (match.child == null) {
+        _searchIndex = 0;
+        foundPath = '';
+        final match = await _tryFind(
+          routes,
+          _searchIndex,
+          forcePath: path.pathSegments.join('/'),
+        );
+        if (match != null) {
+          return match;
+        }
         return QRouteInternal.notFound(parentPath + path.toString());
       }
       match = match.child!;
@@ -197,8 +207,8 @@ class MatchController {
   }
 
   Future<QRouteInternal?> _tryFind(QRouteChildren routes, int index,
-      {bool updatePath = true}) async {
-    final path = index == -1 ? '' : this.path.pathSegments[index];
+      {bool updatePath = true, String? forcePath}) async {
+    final path = index == -1 ? '' : forcePath ?? this.path.pathSegments[index];
 
     bool isSamePath(QRouteInternal route) => route.route.path == '/$path';
 


### PR DESCRIPTION
``` dart
routerDelegate: QRouterDelegate(
        [
          QRoute(
            path: '/',
            builder: () => Main(),
          ),

          QRoute.withChild(
            path: '/auth',
            children: [
              QRoute(
                path: 'login',
                builder: () => Home("login"),
              )
            ],
            builderChild: (r) {
              return Shell(r);
            },
          ),
          QRoute(
            path: '/auth/home',
            builder: () => Home("home"),
          ),
        ],
        initPath: '/',
        observers: [],
      ),
```

Here's an example:
When I normally access /auth/login using QR.to('/auth/login'), the result is as expected.
However, when I access QR.to('/auth/home'), it fails to match the path because home cannot be found within the children of /auth.
I expect the result to match /auth/home, which is consistent with the result under go_route.